### PR TITLE
Add II-Commons

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ This section contains agent frameworks and tools that are useful for data scienc
 ### Research & Knowledge Retrieval
 - [BGPT MCP](https://bgpt.pro/mcp) - MCP server that gives AI agents access to a database of scientific papers built from raw experimental data extracted from full-text studies. Returns 25+ structured fields per paper including methods, results, sample sizes, and quality scores. [GitHub](https://github.com/connerlambden/bgpt-mcp)
 - [Chunk Tuner](https://github.com/shantanu-deshmukh/chunktuner) - Open-source Python library and MCP server to benchmark document chunking strategies for RAG, score retrieval quality, and recommend configurations for a corpus.
+- [II-Commons](https://github.com/Intelligent-Internet/II-Commons-Skills) - Daily-updated skill and CLI for deterministic retrieval across arXiv, PubMed/PMC, and supported US policy corpora.
 
 - [Suppr](https://suppr.wilddata.cn/) - AI literature search, document translation, and deep-research workspace for researchers.
 


### PR DESCRIPTION
Adds II-Commons to Research & Knowledge Retrieval.\n\nII-Commons is an open-source skill and CLI for deterministic retrieval across arXiv, PubMed/PMC, and supported US policy corpora. It is useful for data science and research-agent workflows that need reproducible literature or policy evidence retrieval with daily-updated freshness cutoffs.\n\nProject: https://github.com/Intelligent-Internet/II-Commons-Skills