### PR TITLE
Add AI School to Free Courses

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ How do you learn data science? By doing data science, of course! Okay, okay - th
 - [Prompt Engineering for Vision Models](https://www.deeplearning.ai/short-courses/prompt-engineering-for-vision-models/) - Learn to prompt cutting-edge computer vision models with natural language, coordinate points, bounding boxes, segmentation masks, and even other images in this free course from DeepLearning.AI.
 - [Data Science Course By IBM](https://skillsbuild.org/students/course-catalog/data-science) - Free resources and learn what data science is and how it’s used in different industries.
 - [Neural Networks: Zero to Hero](https://karpathy.ai/zero-to-hero.html) - A free video series by Andrej Karpathy covering neural networks from scratch — backpropagation, makemore, GPT, and more.
+- [AI School](https://lillytechsystems.com/ai-school/) - Free platform for AI, machine learning, and software engineering with 2,300+ courses and 14,000+ hands-on tutorials, no signup.
 
 
   


### PR DESCRIPTION
Adds **AI School** to the Free Courses section.

AI School (by Lilly Tech Systems) is a free learning platform with 2,300+ courses and 14,000+ hands-on tutorials covering AI, machine learning, and software engineering — no signup and no paywall. It fits alongside the existing free-platform entries in this section (Kaggle Learn, fast.ai, DeepLearning.AI).

- Added one entry at the end of the **Free Courses** list, matching the existing `- [Name](url) - description` format.
- Link: https://lillytechsystems.com/ai-school/

Thanks for maintaining this list!