### PR TITLE
Add Verified Supplement Evidence dataset to Datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1213,6 +1213,7 @@ Some data mining competition platforms
 - [latamdata-py](https://github.com/juanmoisesd/latamdata-py) - Python package for one-line access to 38 open research datasets from Latin America (health, neuroscience, mental health, economics). pip install latamdata-py.
 - [ZipCheckup](https://github.com/artakulov/us-water-quality-data) - Free ZIP-level environmental safety data for 42,000+ US ZIP codes: water quality, air quality, PFAS contamination, radon, lead, flood risk, and 11 more verticals. Public REST API, npm/PyPI packages, CC BY 4.0.
 - [Helium](https://heliumtrades.com/mcp-page/) - Real-time news corpus with structured bias features across 15+ dimensions (3.2M+ articles, 5,000+ sources), live financial market data (stocks, ETFs, crypto) with AI-generated analysis, ML options pricing with probability metrics and full Greeks, historical options chain data for quantitative research; available via MCP server or REST API.
+- [Verified Supplement Evidence](https://github.com/erinheit451/verified-supplement-evidence) - Evidence-graded dietary-supplement dataset covering dosing, bioavailability by form, drug-nutrient interactions, NHANES deficiency prevalence, FDA FAERS adverse-event signals, and cost-per-effective-dose, with every clinical claim citing a PubMed PMID. CC BY 4.0, DOI 10.57967/hf/9356.
 
 
 ### Comics


### PR DESCRIPTION
## Summary

Adds **Verified Supplement Evidence** to the **Datasets** section. It is an open, evidence-graded dataset of dietary-supplement data — dosing, bioavailability by form, drug-nutrient interactions, NHANES deficiency prevalence, FDA FAERS adverse-event signals, and cost-per-effective-dose — with every clinical claim citing a PubMed PMID.

- Repo: https://github.com/erinheit451/verified-supplement-evidence
- DOI: 10.57967/hf/9356

## Tip Requirement (Required)

- [x] Fully open source: $1 one-time tip.

Tip details/link: https://github.com/sponsors/hmert

## License Type (Required)

- [x] Creative Commons (CC-BY, CC-BY-SA, etc.)

License details (required): CC BY 4.0

## Your Relationship to This Project (Required)

- [x] Owner

## Checklist

- [x] I confirm the information above is accurate.
- [x] I have read `CONTRIBUTING.md` and followed the repository format.
- [x] I verified links and descriptions in my change.
