### PR TITLE
Add College ROI Dataset to Datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1141,6 +1141,7 @@ Some data mining competition platforms
 - [Academic Torrents](https://academictorrents.com/)
 - [ADS-B Exchange](https://www.adsbexchange.com/data-samples/) - Specific datasets for aircraft and Automatic Dependent Surveillance-Broadcast (ADS-B) sources.
 - [Chinese Tea Dataset](https://chinatea.house/dataset/) - Curated open dataset of 100+ Chinese teas with category, origin, caffeine level, flavor notes, oxidation, and brewing parameters. Available as JSON and CSV.
+- [College ROI Dataset](https://github.com/thomasthinks/college-roi-data) - Lifetime return-on-investment estimates for 29,700 US bachelor's programs across 3,392 colleges, built from FREOPP, IPEDS, and BEA regional price data. 5 CSVs with data dictionary, CC BY 4.0, Zenodo DOI.
 - [AI Displacement Tracker](https://github.com/noahaust2/ai-displacement-tracker) - Structured dataset tracking 92 AI-attributed workforce reduction events affecting 453,748 workers across 12 countries and 11 sectors. JSON and CSV formats. CC-BY-4.0 licensed.
 - [Packrift Packaging Optimization Benchmark Corpus](https://packrift.github.io/packaging-optimization-benchmark-corpus/) - Public packaging product dataset generated from 1,000 exact-spec SKU records, with downloadable CSV and JSON files for ecommerce fulfillment and warehouse analysis.
 - [hadoopilluminated.com](https://hadoopilluminated.com/hadoop_illuminated/Public_Bigdata_Sets.html)


### PR DESCRIPTION
## Summary

Adds the College ROI Dataset to the Datasets section: an open dataset of lifetime return-on-investment estimates for 29,700 US bachelor's programs across 3,392 colleges, derived from FREOPP program-level ROI, IPEDS 2023-24 costs, and BEA regional price parities. 5 CSVs with datapackage.json data dictionary and CITATION.cff; mirrored on Hugging Face, Kaggle, Zenodo (DOI 10.5281/zenodo.21351603), figshare, OpenML, and OSF.

## Tip Requirement (Required)

- [x] Fully open source: $1 one-time tip.
- [ ] Service or closed source: $1 monthly tip or $12 yearly tip.

Tip details/link: $1 one-time tip sent to https://github.com/sponsors/hmert on 2026-07-15.

## License Type (Required)

- [x] Creative Commons (CC-BY, CC-BY-SA, etc.)

License details (required): CC-BY-4.0

## Your Relationship to This Project (Required)

- [x] Owner

## Checklist

- [x] I confirm the information above is accurate.
- [x] I have read `CONTRIBUTING.md` and followed the repository format.
- [x] I verified links and descriptions in my change.