### PR TITLE
Add Lumen to Agents > Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ This section contains agent frameworks and tools that are useful for data scienc
 
 ### Frameworks
 - [ADK-Rust](https://github.com/zavora-ai/adk-rust) - Production-ready AI agent development kit for Rust with model-agnostic design (Gemini, OpenAI, Anthropic), multiple agent types (LLM, Graph, Workflow), MCP support, and built-in telemetry.
+- [Lumen](https://github.com/holoviz/lumen) - Agent framework for chatting with data, turning natural language into SQL, transformation pipelines and visualizations. Outputs are declarative specs that can be inspected, edited, reopened in a notebook or composed into a dashboard.
 
 ### Tools
 - [Frostbyte MCP](https://github.com/OzorOwn/frostbyte-mcp) - MCP server providing 13 data tools for AI agents: real-time crypto prices, IP geolocation, DNS lookups, web scraping to markdown, code execution, and screenshots. One API key for 40+ services.


### PR DESCRIPTION
## Summary

Adds Lumen to Agents > Frameworks.

Lumen is an open-source agent framework for conversational data analysis, built on Panel. It connects to local files, SQL databases, data lakes and multidimensional array data, and generates SQL, transformation pipelines and charts from natural language. Every output serializes to YAML, so an analysis stays reproducible and can be reopened in a notebook rather than ending at a chat message.

It matches the section description, and Frameworks currently lists only a Rust toolkit, so this adds the first Python entry.

- Repo: https://github.com/holoviz/lumen
- Docs: https://lumen.holoviz.org


## License Type (Required)

- [x] BSD-3-Clause

License details (required): BSD-3-Clause. NumFOCUS-affiliated HoloViz project alongside Panel, HoloViews and Datashader.

## Your Relationship to This Project (Required)

- [x] Maintainer

## Checklist

- [x] I confirm the information above is accurate.
- [x] I have read `CONTRIBUTING.md` and followed the repository format.
- [x] I verified links and descriptions in my change.