### PR TITLE
Add HDD Price Index to Datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1211,6 +1211,7 @@ Some data mining competition platforms
 - [The Humanitarian Data Exchange](https://data.humdata.org/)
 - [250k+ Job Postings](https://aws.amazon.com/marketplace/pp/prodview-p2554p3tczbes) - An expanding dataset of historical job postings from Luxembourg from 2020 to today. Free with 250k+ job postings hosted on AWS Data Exchange.
 - [FinancialData.Net](https://financialdata.net/documentation) - Financial datasets (stock market data, financial statements, sustainability data, and more).
+- [HDD Price Index](https://github.com/AdamDudley/hddhunt-price-index) - Daily open dataset of the cheapest new internal 3.5" SATA hard-drive price per terabyte (USD/TB) by capacity tier on Amazon US, with a historical time series. CSV, JSON and JSONL, no login, CC BY 4.0.
 - [BDE Score](https://github.com/hbhqq9/bde-score) - AI-powered multi-market stock analysis with transparent BDE scoring across 73 stocks (US/HK/A-share). EU AI Act Art.50 compliant. MIT license.
 - [Google Dataset Search](https://datasetsearch.research.google.com/) – Find datasets across the web.
 - [notesjor corpus-collection](https://notes.jan-oliver-ruediger.de/korpora/) - Free corpora (over 6 billion tokens) mostly German (both historically and in contemporary German).


### PR DESCRIPTION
## Summary

Adds the **HDD Price Index** open dataset to the **Data Sets** section, placed near the existing economic/financial dataset entries (FinancialData.Net, etc.).

- `[HDD Price Index](https://github.com/AdamDudley/hddhunt-price-index)` — Daily open dataset of the cheapest new internal 3.5" SATA hard-drive price per terabyte (USD/TB) by capacity tier on Amazon US, with a historical time series. Root-level CSV, JSON and JSONL; no login/auth required.
- Entry format matches the section style `[Name](URL) - description`, one sentence, no marketing language, `https://` source link, placed next to similar datasets.

## Tip Requirement (Required)

- [x] Fully open source: $1 one-time tip.

The dataset is fully open source (public GitHub repository, CC BY 4.0, no paid tier or closed service).

Tip link acknowledged: https://github.com/sponsors/hmert

## License Type (Required)

- [x] Creative Commons (CC-BY, CC-BY-SA, etc.)

License details: **CC BY 4.0** (data), MIT (accompanying refresh script). Declared in the repository `LICENSE` and `README.md`.

## Your Relationship to This Project (Required)

- [x] Owner

I author and maintain the dataset; submitting under my own GitHub identity.

## Checklist

- [x] I confirm the information above is accurate.
- [x] I have read `CONTRIBUTING.md` and followed the repository format (single bullet in the most relevant section, existing style, https link, no marketing language, placed near similar entries).
- [x] I verified links and descriptions in my change.
