### PR TITLE
Add DataInt Databook and Logibook to Datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1161,6 +1161,7 @@ Some data mining competition platforms
 - [NASDAQ:DATA](https://data.nasdaq.com/) - Nasdaq Data Link A premier source for financial, economic and alternative datasets.
 - [Congressional Stock Brain](https://congressionalstockbrain.com) - Free AI-powered tool that scores U.S. congressional STOCK Act trade disclosures by significance. Machine-scored signals from 537 lawmakers's public trade filings.
 - [figshare.com](https://figshare.com/)
+- [DataInt Databook](https://databook.dataint.net) - Country reference pages for 250 countries covering population, economy, geography, infrastructure, defence and governance, compiled from World Bank, UN agencies, UNESCO and the World Factbook with the source shown next to each figure. Web reference in 25 languages; no bulk download or API.
 - [GeoLite Legacy Downloadable Databases](https://dev.maxmind.com/geoip)
 - [Hugging Face Datasets](https://huggingface.co/datasets)
 - [Japan Neighborhoods](https://japanneighborhoods.com) - English dataset of Tokyo crime statistics across 5,078 neighborhoods × 7 years (36,222 records, 2018-2024), sourced from Tokyo Metropolitan Police open data. Includes interactive crime map, safety grading, and cost-of-living index. CC BY licensed.

--- a/README.md
+++ b/README.md
@@ -1162,6 +1162,7 @@ Some data mining competition platforms
 - [Congressional Stock Brain](https://congressionalstockbrain.com) - Free AI-powered tool that scores U.S. congressional STOCK Act trade disclosures by significance. Machine-scored signals from 537 lawmakers's public trade filings.
 - [figshare.com](https://figshare.com/)
 - [DataInt Databook](https://databook.dataint.net) - Country reference pages for 250 countries covering population, economy, geography, infrastructure, defence and governance, compiled from World Bank, UN agencies, UNESCO and the World Factbook with the source shown next to each figure. Web reference in 25 languages; no bulk download or API.
+- [DataInt Logibook](https://logibook.dataint.net) - Logistics and transport reference by country: ports, airports, airlines, free trade zones, customs regimes, dangerous-goods classes and HS commodity codes, consolidated from OpenFlights, OpenTravelData, UNCTAD and official aviation and maritime sources. Web reference in 25 languages; no bulk download or API.
 - [GeoLite Legacy Downloadable Databases](https://dev.maxmind.com/geoip)
 - [Hugging Face Datasets](https://huggingface.co/datasets)
 - [Japan Neighborhoods](https://japanneighborhoods.com) - English dataset of Tokyo crime statistics across 5,078 neighborhoods × 7 years (36,222 records, 2018-2024), sourced from Tokyo Metropolitan Police open data. Includes interactive crime map, safety grading, and cost-of-living index. CC BY licensed.


### PR DESCRIPTION
Adds two entries to the **Datasets** section — the two reference sites we publish, one for country data and one for logistics.

**DataInt Databook** — country reference pages for 250 countries: population, economy, geography, infrastructure, defence, governance. Compiled from World Bank, UN agencies, UNESCO and the World Factbook.

**DataInt Logibook** — the logistics counterpart, organised the same way: ports, airports, airlines, free trade zones, customs regimes, dangerous-goods classes and HS commodity codes, per country. Consolidated from OpenFlights, OpenTravelData, UNCTAD and official aviation and maritime sources. This one sits close to ADS-B Exchange, already on the list.

Both name the publishing institution next to each figure, so a reader can verify against the original source rather than taking ours. Published in 25 languages.

**Limits, written into both entries:**
- Web reference only — no bulk download, no CSV/JSON export, no API.
- No original data collection; everything is compiled from public sources.
- The sites carry advertising.

They're closer in kind to enigma.com (already listed) than to Kaggle or figshare — places to look a figure up and find its source, not places to pull files from.

**Disclosure:** I maintain both sites, so this is a self-submission. Entirely reasonable to close it, or to take only one of the two, if that fits the list better.
