### PR TITLE
Add The Thinking Machine to Tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ How do you learn data science? By doing data science, of course! Okay, okay - th
 - [Top 100+ Data Science Interview Questions and Answers](https://www.appliedaicourse.com/blog/data-science-interview-questions/)
 - [DataDriven - SQL, Python, and Data Modeling Interview Questions](https://www.datadriven.io/)
 - [StepByStepML](https://www.stepbystepml.com) - Interactive calculator that visualizes the step-by-step manual math behind machine learning algorithms for exam prep.
+- [The Thinking Machine](https://thethinkingmachine.dev) - Interactive essay on AI from 1972 to 2026, with a neural network that trains in the browser via real backpropagation.
 - [How to Build Optimal AI Agents That Actually Work](https://www.freecodecamp.org/news/how-to-build-optimal-ai-agents-that-actually-work-a-handbook-for-devs/) - A developer handbook on designing and building effective AI agents.
 - [Train LLM From Scratch](https://github.com/FareedKhan-dev/train-llm-from-scratch) - A straightforward method for training your LLM, from downloading data to generating text.
 


### PR DESCRIPTION
Adds an interactive essay explaining AI from first principles — history, neural networks, transformers, training, and the hardware supply chain.

The demos compute rather than animate: the neural network trains with real backpropagation in the browser (pick the spiral with 2 hidden units and watch it fail, then 16 and watch it work), and the overfitting demo solves least squares live as you drag the polynomial degree.

Free, no ads, no signup, no tracking of readers across sites. Available in English and French, each in two reading levels. Every source is listed on a public page, with the weaker ones flagged as such.

Placed in Training Resources > Tutorials, next to StepByStepML, which it most resembles.